### PR TITLE
Add hooks with selection logic

### DIFF
--- a/src/component/Checkbox.js
+++ b/src/component/Checkbox.js
@@ -1,36 +1,27 @@
 import { createElement, useCallback } from "react"
 
-import { useFormContext } from "../context/form"
+import useSimpleSelection from "../selection/simple"
 
 const Checkbox = props => {
   const { field, value, ...restProps } = props
-  const { transformValue, value: selectedValues } = useFormContext(field)
-  const valueSet = selectedValues || new Set()
-  const checked = valueSet.has(value)
+  const { selectValue, selected } = useSimpleSelection(field, value)
 
   const handleChange = useCallback(
     event => {
       const { checked, value } = event.target
 
-      transformValue((valueSet = new Set()) => {
-        const nextValueSet = new Set(valueSet)
-
-        if (checked) nextValueSet.add(value)
-        else nextValueSet.delete(value)
-
-        return nextValueSet
-      })
+      selectValue(value, checked)
     },
-    [transformValue]
+    [selectValue]
   )
 
   return (
     <input
       {...restProps}
-      type="checkbox"
-      checked={checked}
-      value={value}
+      checked={selected}
       onChange={handleChange}
+      type="checkbox"
+      value={value}
     />
   )
 }

--- a/src/component/MultiSelect.js
+++ b/src/component/MultiSelect.js
@@ -1,0 +1,33 @@
+import { createElement, useCallback } from "react"
+
+import useMultipleSelection from "../selection/multiple"
+import { createSet } from "../util/structures"
+
+const pluckValue = ({ value }) => value
+
+const MultiSelect = props => {
+  const { field, ...restProps } = props
+  const { selectValues, selectedValues } = useMultipleSelection(field)
+  const valueArray = Array.from(selectedValues)
+
+  const handleChange = useCallback(
+    event => {
+      const { selectedOptions } = event.target
+      const nextValueSet = createSet(selectedOptions, pluckValue)
+
+      selectValues(nextValueSet)
+    },
+    [selectValues]
+  )
+
+  return (
+    <select
+      {...restProps}
+      multiple={true}
+      onChange={handleChange}
+      value={valueArray}
+    />
+  )
+}
+
+export default MultiSelect

--- a/src/component/Radio.js
+++ b/src/component/Radio.js
@@ -1,26 +1,25 @@
 import { createElement, useCallback } from "react"
 
-import { useFormContext } from "../context/form"
+import useSingleSelection from "../selection/single"
 
 const Radio = props => {
   const { field, value, ...restProps } = props
-  const { setValue, value: selectedValue } = useFormContext(field)
-  const checked = value === selectedValue
+  const { selectValue, selected } = useSingleSelection(field, value)
 
   const handleChange = useCallback(
     event => {
-      setValue(event.target.value)
+      selectValue(event.target.value)
     },
-    [setValue]
+    [selectValue]
   )
 
   return (
     <input
       {...restProps}
-      type="radio"
-      checked={checked}
-      value={value}
+      checked={selected}
       onChange={handleChange}
+      type="radio"
+      value={value}
     />
   )
 }

--- a/src/component/Select.js
+++ b/src/component/Select.js
@@ -1,32 +1,25 @@
 import { createElement, useCallback } from "react"
 
-import { useFormContext } from "../context/form"
-import { createSet } from "../util/structures"
-
-const pluckValue = ({ value }) => value
+import useSingleSelection from "../selection/single"
 
 const Select = props => {
-  const { field, multiple, ...restProps } = props
-  const { setValue, value: selectedValues } = useFormContext(field)
-  const valueArray = Array.from(selectedValues || "")
-  const value = multiple ? valueArray : valueArray.shift() || ""
+  const { field, ...restProps } = props
+  const { selectValue, selectedValue } = useSingleSelection(field)
+  const value = selectedValue || ""
 
   const handleChange = useCallback(
     event => {
-      const { selectedOptions } = event.target
-      const nextValueSet = createSet(selectedOptions, pluckValue)
-
-      setValue(nextValueSet)
+      selectValue(event.target.value)
     },
-    [setValue]
+    [selectValue]
   )
 
   return (
     <select
       {...restProps}
-      multiple={multiple}
-      value={value}
+      multiple={null}
       onChange={handleChange}
+      value={value}
     />
   )
 }

--- a/src/component/__tests__/MultiSelect.test.js
+++ b/src/component/__tests__/MultiSelect.test.js
@@ -1,7 +1,7 @@
 import { createElement } from "react"
 import TestRenderer from "react-test-renderer"
 
-import Select from "../Select"
+import MultiSelect from "../MultiSelect"
 import { FormProvider } from "../../context/form"
 
 const field = "a"
@@ -12,51 +12,54 @@ afterEach(() => {
   dispatch.mockClear()
 })
 
-describe("Select", () => {
+describe("MultiSelect", () => {
   it("renders correctly", () => {
     const state = getState()
     const tree = TestRenderer.create(
       <FormProvider value={[state, dispatch]}>
-        <Select field={field} />
+        <MultiSelect field={field} />
       </FormProvider>
     ).toJSON()
 
     expect(tree).toMatchSnapshot()
+    expect(tree.props.multiple).toBe(true)
   })
 
-  it("casts `undefined` value to empty string", () => {
+  it("casts `undefined` value to empty array", () => {
     const state = getState()
     const tree = TestRenderer.create(
       <FormProvider value={[state, dispatch]}>
-        <Select field={field} />
+        <MultiSelect field={field} />
       </FormProvider>
     ).toJSON()
 
-    expect(tree.props.value).toBe("")
+    expect(tree.props.value).toBeInstanceOf(Array)
+    expect(tree.props.value).toHaveLength(0)
   })
 
-  it("casts `null` value to empty string", () => {
+  it("casts `null` value to empty array", () => {
     const state = getState(null)
     const tree = TestRenderer.create(
       <FormProvider value={[state, dispatch]}>
-        <Select field={field} />
+        <MultiSelect field={field} />
       </FormProvider>
     ).toJSON()
 
-    expect(tree.props.value).toBe("")
+    expect(tree.props.value).toBeInstanceOf(Array)
+    expect(tree.props.value).toHaveLength(0)
   })
 
   it("dispatches on change", () => {
-    const state = getState("b")
-    const nextValue = "c"
+    const state = getState(new Set().add("b"))
+    const nextValue = new Set().add("b").add("c")
     const tree = TestRenderer.create(
       <FormProvider value={[state, dispatch]}>
-        <Select field={field} />
+        <MultiSelect field={field} />
       </FormProvider>
     ).toJSON()
 
     tree.props.onChange({
-      target: { value: nextValue },
+      target: { selectedOptions: Array.from(nextValue, value => ({ value })) },
     })
 
     expect(dispatch).toHaveBeenCalledTimes(1)
@@ -67,11 +70,11 @@ describe("Select", () => {
   })
 
   it("memoizes its change handler", () => {
-    const state = getState()
-    const nextValue = "b"
+    const state = getState(new Set())
+    const nextValue = new Set().add("b").add("c")
     const tree = TestRenderer.create(
       <FormProvider value={[state, dispatch]}>
-        <Select field={field} />
+        <MultiSelect field={field} />
       </FormProvider>
     )
 
@@ -80,7 +83,7 @@ describe("Select", () => {
 
     tree.update(
       <FormProvider value={[nextState, dispatch]}>
-        <Select field={field} />
+        <MultiSelect field={field} />
       </FormProvider>
     )
 

--- a/src/component/__tests__/__snapshots__/MultiSelect.test.js.snap
+++ b/src/component/__tests__/__snapshots__/MultiSelect.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MultiSelect renders correctly 1`] = `
+<select
+  multiple={true}
+  onChange={[Function]}
+  value={Array []}
+/>
+`;

--- a/src/component/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/component/__tests__/__snapshots__/Select.test.js.snap
@@ -1,16 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Select multiple={false} renders correctly 1`] = `
+exports[`Select renders correctly 1`] = `
 <select
+  multiple={null}
   onChange={[Function]}
   value=""
-/>
-`;
-
-exports[`Select multiple={true} renders correctly 1`] = `
-<select
-  multiple={true}
-  onChange={[Function]}
-  value={Array []}
 />
 `;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,14 @@
 export { default as Checkbox } from "./component/Checkbox"
 export { default as Form } from "./component/Form"
+export { default as MultiSelect } from "./component/MultiSelect"
 export { default as Radio } from "./component/Radio"
 export { default as Scope } from "./component/Scope"
 export { default as Select } from "./component/Select"
 export { default as Text } from "./component/Text"
 export { default as TextArea } from "./component/TextArea"
+
+export { useFormContext } from "./context/form"
+
+export { default as useMultipleSelection } from "./selection/multiple"
+export { default as useSimpleSelection } from "./selection/simple"
+export { default as useSingleSelection } from "./selection/single"

--- a/src/selection/__tests__/multiple.test.js
+++ b/src/selection/__tests__/multiple.test.js
@@ -1,0 +1,70 @@
+import { createElement } from "react"
+import TestRenderer from "react-test-renderer"
+
+import useMultipleSelection from "../multiple"
+import { FormProvider } from "../../context/form"
+
+const field = "a"
+const log = jest.fn()
+const dispatch = jest.fn()
+const getState = value => ({ valueMap: new Map().set(field, value) })
+
+afterEach(() => {
+  log.mockClear()
+  dispatch.mockClear()
+})
+
+describe("useMultipleSelection", () => {
+  it("returns the selected values and a callback", () => {
+    const value = new Set().add("b").add("c")
+    const state = getState(value)
+
+    const Component = () => {
+      const context = useMultipleSelection(field)
+      log(context)
+      return <i />
+    }
+
+    TestRenderer.create(
+      <FormProvider value={[state, dispatch]}>
+        <Component />
+      </FormProvider>
+    )
+
+    expect(log).toHaveBeenCalledTimes(1)
+    expect(log).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selectValues: expect.any(Function),
+        selectedValues: value,
+      })
+    )
+  })
+})
+
+describe("useMultipleSelection's selectValues", () => {
+  it("dispatches", () => {
+    let selectValues
+    const state = getState()
+    const nextValue = new Set().add("c").add("d")
+
+    const Component = () => {
+      const context = useMultipleSelection(field)
+      selectValues = context.selectValues
+      return <i />
+    }
+
+    TestRenderer.create(
+      <FormProvider value={[state, dispatch]}>
+        <Component />
+      </FormProvider>
+    )
+
+    selectValues(nextValue)
+
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    expect(dispatch).toHaveBeenLastCalledWith({
+      type: "set value",
+      payload: { field, nextValue },
+    })
+  })
+})

--- a/src/selection/__tests__/simple.test.js
+++ b/src/selection/__tests__/simple.test.js
@@ -1,0 +1,106 @@
+import { createElement } from "react"
+import TestRenderer from "react-test-renderer"
+
+import useSimpleSelection from "../simple"
+import { FormProvider } from "../../context/form"
+
+const field = "a"
+const dispatch = jest.fn()
+const getState = value => ({ valueMap: new Map().set(field, value) })
+
+afterEach(() => {
+  dispatch.mockClear()
+})
+
+describe("useSimpleSelection", () => {
+  it("returns the selected value and a callback", () => {
+    let context
+    const value = new Set().add("b").add("c")
+    const state = getState(value)
+
+    const Component = () => {
+      context = useSimpleSelection(field)
+      return <i />
+    }
+
+    TestRenderer.create(
+      <FormProvider value={[state, dispatch]}>
+        <Component />
+      </FormProvider>
+    )
+
+    expect(context).toEqual(
+      expect.objectContaining({
+        selectValue: expect.any(Function),
+        selected: false,
+        selectedValues: value,
+      })
+    )
+  })
+
+  it("returns `selected: true` if `value` is selected", () => {
+    let context
+    const value = new Set().add("b").add("c")
+    const state = getState(value)
+
+    const Component = () => {
+      context = useSimpleSelection(field, "b")
+      return <i />
+    }
+
+    TestRenderer.create(
+      <FormProvider value={[state, dispatch]}>
+        <Component />
+      </FormProvider>
+    )
+
+    expect(context.selected).toBe(true)
+  })
+
+  it("returns `selected: false` if `value` is unselected", () => {
+    let context
+    const value = new Set().add("b").add("c")
+    const state = getState(value)
+
+    const Component = () => {
+      context = useSimpleSelection(field, "d")
+      return <i />
+    }
+
+    TestRenderer.create(
+      <FormProvider value={[state, dispatch]}>
+        <Component />
+      </FormProvider>
+    )
+
+    expect(context.selected).toBe(false)
+  })
+})
+
+describe("useSimpleSelection's selectValue", () => {
+  it("dispatches", () => {
+    let selectValue
+    const state = getState()
+    const nextValue = "c"
+
+    const Component = () => {
+      const context = useSimpleSelection(field)
+      selectValue = context.selectValue
+      return <i />
+    }
+
+    TestRenderer.create(
+      <FormProvider value={[state, dispatch]}>
+        <Component />
+      </FormProvider>
+    )
+
+    selectValue(nextValue)
+
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    expect(dispatch).toHaveBeenLastCalledWith({
+      type: "transform value",
+      payload: { field, transformValue: expect.any(Function) },
+    })
+  })
+})

--- a/src/selection/__tests__/single.test.js
+++ b/src/selection/__tests__/single.test.js
@@ -1,0 +1,106 @@
+import { createElement } from "react"
+import TestRenderer from "react-test-renderer"
+
+import useSingleSelection from "../single"
+import { FormProvider } from "../../context/form"
+
+const field = "a"
+const dispatch = jest.fn()
+const getState = value => ({ valueMap: new Map().set(field, value) })
+
+afterEach(() => {
+  dispatch.mockClear()
+})
+
+describe("useSingleSelection", () => {
+  it("returns the selected value and a callback", () => {
+    let context
+    const value = "b"
+    const state = getState(value)
+
+    const Component = () => {
+      context = useSingleSelection(field)
+      return <i />
+    }
+
+    TestRenderer.create(
+      <FormProvider value={[state, dispatch]}>
+        <Component />
+      </FormProvider>
+    )
+
+    expect(context).toEqual(
+      expect.objectContaining({
+        selectValue: expect.any(Function),
+        selected: false,
+        selectedValue: value,
+      })
+    )
+  })
+
+  it("returns `selected: true` if `value` is selected", () => {
+    let context
+    const value = "b"
+    const state = getState(value)
+
+    const Component = () => {
+      context = useSingleSelection(field, "b")
+      return <i />
+    }
+
+    TestRenderer.create(
+      <FormProvider value={[state, dispatch]}>
+        <Component />
+      </FormProvider>
+    )
+
+    expect(context.selected).toBe(true)
+  })
+
+  it("returns `selected: false` if `value` is unselected", () => {
+    let context
+    const value = "b"
+    const state = getState(value)
+
+    const Component = () => {
+      context = useSingleSelection(field, "c")
+      return <i />
+    }
+
+    TestRenderer.create(
+      <FormProvider value={[state, dispatch]}>
+        <Component />
+      </FormProvider>
+    )
+
+    expect(context.selected).toBe(false)
+  })
+})
+
+describe("useSingleSelection's selectValue", () => {
+  it("dispatches", () => {
+    let selectValue
+    const state = getState()
+    const nextValue = "c"
+
+    const Component = () => {
+      const context = useSingleSelection(field)
+      selectValue = context.selectValue
+      return <i />
+    }
+
+    TestRenderer.create(
+      <FormProvider value={[state, dispatch]}>
+        <Component />
+      </FormProvider>
+    )
+
+    selectValue(nextValue)
+
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    expect(dispatch).toHaveBeenLastCalledWith({
+      type: "set value",
+      payload: { field, nextValue },
+    })
+  })
+})

--- a/src/selection/multiple.js
+++ b/src/selection/multiple.js
@@ -1,0 +1,13 @@
+import { createElement } from "react"
+
+import { useFormContext } from "../context/form"
+
+export default field => {
+  const { setValue, value: selectedValues } = useFormContext(field)
+  const valueSet = selectedValues || new Set()
+
+  return {
+    selectValues: setValue,
+    selectedValues: valueSet,
+  }
+}

--- a/src/selection/simple.js
+++ b/src/selection/simple.js
@@ -1,0 +1,29 @@
+import { createElement, useCallback } from "react"
+
+import { useFormContext } from "../context/form"
+
+export default (field, value) => {
+  const { transformValue, value: selectedValues } = useFormContext(field)
+  const valueSet = selectedValues || new Set()
+  const selected = valueSet.has(value)
+
+  const selectValue = useCallback(
+    (value, selected) => {
+      transformValue((valueSet = new Set()) => {
+        const nextValueSet = new Set(valueSet)
+
+        if (selected) nextValueSet.add(value)
+        else nextValueSet.delete(value)
+
+        return nextValueSet
+      })
+    },
+    [transformValue]
+  )
+
+  return {
+    selectValue,
+    selected,
+    selectedValues,
+  }
+}

--- a/src/selection/single.js
+++ b/src/selection/single.js
@@ -1,0 +1,14 @@
+import { createElement } from "react"
+
+import { useFormContext } from "../context/form"
+
+export default (field, value) => {
+  const { setValue, value: selectedValue } = useFormContext(field)
+  const selected = value === selectedValue
+
+  return {
+    selectValue: setValue,
+    selected,
+    selectedValue,
+  }
+}


### PR DESCRIPTION
Add new selection hooks and refactor components to use them.

Type | Hook | Model
--- | --- | ---
simple | `useSimpleSelection` | checkbox
single | `useSingleSelection` | radio
multiple | `useMultipleSelection` | select