### PR TITLE
Refactor Scope

### DIFF
--- a/src/component/Scope.js
+++ b/src/component/Scope.js
@@ -1,20 +1,14 @@
-import { createElement, useEffect } from "react"
+import { createElement, useContext } from "react"
 
-import { FormProvider, useFormContext } from "../context/form"
-import { useFormState } from "../state/form"
+import ScopeContext, { ScopeProvider } from "../context/scope"
+import { join } from "../util/deep"
 
 const Scope = props => {
   const { children, field } = props
-  const { setValue, value } = useFormContext(field)
-  const store = useFormState(value)
-  const { valueMap } = store[0]
-  const empty = !valueMap.size
+  const scope = useContext(ScopeContext)
+  const scopedField = join(scope, field)
 
-  useEffect(() => {
-    if (!empty && !Object.is(value, valueMap)) setValue(valueMap)
-  })
-
-  return <FormProvider value={store}>{children}</FormProvider>
+  return <ScopeProvider value={scopedField}>{children}</ScopeProvider>
 }
 
 export default Scope

--- a/src/component/__tests__/__snapshots__/Scope.test.js.snap
+++ b/src/component/__tests__/__snapshots__/Scope.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Scope renders correctly 1`] = `null`;
+exports[`Scope renders correctly 1`] = `<i />`;

--- a/src/context/form.js
+++ b/src/context/form.js
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext } from "react"
 
-import { getDeepValue } from "../util/deep"
+import ScopeContext from "../context/scope"
+import { getDeepValue, join } from "../util/deep"
 
 const FormContext = createContext()
 const { Consumer, Provider } = FormContext
@@ -10,18 +11,27 @@ export { Consumer as FormConsumer }
 export { Provider as FormProvider }
 
 export const useFormContext = field => {
+  const scope = useContext(ScopeContext)
+  const scopedField = join(scope, field)
   const [state, dispatch] = useContext(FormContext)
-  const value = getDeepValue(state.valueMap, field)
+  const value = getDeepValue(state.valueMap, scopedField)
 
   const setValue = useCallback(
-    nextValue => dispatch({ type: "set value", payload: { field, nextValue } }),
-    [dispatch, field]
+    nextValue =>
+      dispatch({
+        type: "set value",
+        payload: { field: scopedField, nextValue },
+      }),
+    [dispatch, scopedField]
   )
 
   const transformValue = useCallback(
     transformValue =>
-      dispatch({ type: "transform value", payload: { field, transformValue } }),
-    [dispatch, field]
+      dispatch({
+        type: "transform value",
+        payload: { field: scopedField, transformValue },
+      }),
+    [dispatch, scopedField]
   )
 
   return { setValue, transformValue, value }

--- a/src/context/scope.js
+++ b/src/context/scope.js
@@ -1,0 +1,8 @@
+import { createContext } from "react"
+
+const ScopeContext = createContext("")
+const { Consumer, Provider } = ScopeContext
+
+export default ScopeContext
+export { Consumer as ScopeConsumer }
+export { Provider as ScopeProvider }

--- a/src/util/__tests__/deep.test.js
+++ b/src/util/__tests__/deep.test.js
@@ -1,4 +1,4 @@
-import { getDeepValue, setDeepValue, setMapOrValue, split } from "../deep"
+import { getDeepValue, join, setDeepValue, setMapOrValue, split } from "../deep"
 
 describe("split", () => {
   it("returns an array", () => {
@@ -46,6 +46,34 @@ describe("split", () => {
 
     expect(parts).toHaveLength(3)
     expect(parts).toEqual(["a", "0", "b"])
+  })
+})
+
+describe("join", () => {
+  it("returns a string", () => {
+    expect(join()).toBe("")
+  })
+
+  it("joins parts with a dot", () => {
+    const parts = ["a", "b", "c"]
+
+    expect(join(...parts)).toBe("a.b.c")
+  })
+
+  it("joins parts with a dot", () => {
+    const parts = ["a", "b", "c"]
+
+    expect(join(...parts)).toBe("a.b.c")
+  })
+
+  it("omits leading and trailing dots", () => {
+    expect(join("a")).toBe("a")
+  })
+
+  it("omits empty parts", () => {
+    const parts = ["", "b", "c", "", "e"]
+
+    expect(join(...parts)).toBe("b.c.e")
   })
 })
 

--- a/src/util/deep.js
+++ b/src/util/deep.js
@@ -1,5 +1,11 @@
 export const split = path => /(\[\d+\])|\./[Symbol.split](path).filter(Boolean)
 
+export const join = (...parts) =>
+  parts.reduce((path, part) => {
+    const prefix = path && part ? "." : ""
+    return `${path}${prefix}${part}`
+  }, "")
+
 export const setMapOrValue = (valueMap = new Map(), keys, nextValue) => {
   const [key, ...nextKeys] = keys
   const nextValueMap = new Map(valueMap)


### PR DESCRIPTION
Originally, the `Scope` component created a new `FormContext`. This made a `Scope` element transparent to descendant fields. However, behind the scenes, each `Scope` had to relay state changes to its `Form` ancestor, which would trigger a new render. That wasn't performant.

The new `Scope` component simply provides its `field` as context. Fields (and `Scope` itself) can use this context to ascertain the scope they are in and retrieve the correct value from `FormContext`.