### PR TITLE
Upgrade to React 16.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # dependencies
 /node_modules
 
+# error logs
+yarn-error.log
+
 # lock files
 package-lock.json
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "test:dev": "jest --coverage --verbose"
   },
   "peerDependencies": {
-    "react": "16.7.0-alpha.2",
-    "react-dom": "16.7.0-alpha.2"
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",
@@ -35,9 +35,9 @@
     "jest": "^23.6.0",
     "jest-junit": "^5.2.0",
     "prettier": "^1.15.3",
-    "react": "16.7.0-alpha.2",
-    "react-dom": "16.7.0-alpha.2",
-    "react-test-renderer": "16.7.0-alpha.2",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
+    "react-test-renderer": "^16.8.6",
     "rollup": "^0.68.1",
     "rollup-plugin-babel": "^4.1.0"
   },

--- a/src/state/__tests__/form.test.js
+++ b/src/state/__tests__/form.test.js
@@ -1,11 +1,11 @@
 import { createElement } from "react"
 import renderer from "react-test-renderer"
 
-import { reducer, useFormState } from "../form"
+import { init, reducer, useFormState } from "../form"
 
 const log = jest.fn()
 const identity = val => val
-const initialState = reducer()
+const initialState = init()
 const toUpperCase = val => val.toUpperCase()
 const simpleValueMap = new Map().set("a", "b")
 
@@ -147,5 +147,36 @@ describe("reducer's `'transform value'` case", () => {
     const expected = new Map(simpleValueMap).set("a", "B")
 
     expect(valueMap).toEqual(expected)
+  })
+})
+
+describe("reducer's `'reset state'` case", () => {
+  it("returns a new state object", () => {
+    const initialState = { valueMap: simpleValueMap }
+    const type = "reset state"
+    const payload = initialState
+
+    const nextState = reducer(initialState, { payload, type })
+
+    expect(nextState).not.toBe(initialState)
+  })
+
+  it("sets `state.valueMap`", () => {
+    const initialState = { valueMap: simpleValueMap }
+    const type = "reset state"
+    const payload = initialState
+
+    const { valueMap } = reducer(initialState, { payload, type })
+
+    expect(valueMap).toBe(initialState.valueMap)
+  })
+})
+
+describe("reducer's default case", () => {
+  it("returns the current state object", () => {
+    const initialState = { valueMap: simpleValueMap }
+    const nextState = reducer(initialState)
+
+    expect(nextState).toBe(initialState)
   })
 })

--- a/src/state/form.js
+++ b/src/state/form.js
@@ -2,10 +2,9 @@ import { useReducer } from "react"
 
 import { getDeepValue, setDeepValue } from "../util/deep"
 
-const initialValueMap = new Map()
-const initialState = { valueMap: initialValueMap }
+export const init = (valueMap = new Map()) => ({ valueMap })
 
-export const reducer = (state = initialState, action = {}) => {
+export const reducer = (state, action = {}) => {
   const { payload, type } = action
 
   switch (type) {
@@ -25,10 +24,10 @@ export const reducer = (state = initialState, action = {}) => {
 
       return { valueMap: nextValueMap }
     }
-    case "initialize values": {
+    case "reset state": {
       const { valueMap } = payload
 
-      return { valueMap }
+      return init(valueMap)
     }
     default: {
       return state
@@ -36,11 +35,4 @@ export const reducer = (state = initialState, action = {}) => {
   }
 }
 
-export const useFormState = (valueMap = initialValueMap) => {
-  const initialAction = {
-    payload: { valueMap },
-    type: "initialize values",
-  }
-
-  return useReducer(reducer, initialState, initialAction)
-}
+export const useFormState = valueMap => useReducer(reducer, valueMap, init)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3760,40 +3760,40 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@16.7.0-alpha.2:
-  version "16.7.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.7.0-alpha.2.tgz#16632880ed43676315991d8b412cce6975a30282"
-  integrity sha512-o0mMw8jBlwHjGZEy/vvKd/6giAX0+skREMOTs3/QHmgi+yAhUClp4My4Z9lsKy3SXV+03uPdm1l/QM7NTcGuMw==
+react-dom@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.12.0-alpha.2"
+    scheduler "^0.13.6"
 
-react-is@^16.7.0-alpha.2:
-  version "16.7.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
-  integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
+react-is@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-test-renderer@16.7.0-alpha.2:
-  version "16.7.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.7.0-alpha.2.tgz#8606a5a82240c405539da0401d7b3572898b5611"
-  integrity sha512-taA9MrHMi7hEM/cKgvcvht+9cszhPirCaSP99yxkVQ2JwQxYSltGYq2gFf/UQBqGJMgmgEghN62rxziaL1EK+A==
+react-test-renderer@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.8.6.tgz#188d8029b8c39c786f998aa3efd3ffe7642d5ba1"
+  integrity sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==
   dependencies:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    react-is "^16.7.0-alpha.2"
-    scheduler "^0.12.0-alpha.2"
+    react-is "^16.8.6"
+    scheduler "^0.13.6"
 
-react@16.7.0-alpha.2:
-  version "16.7.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.7.0-alpha.2.tgz#924f2ae843a46ea82d104a8def7a599fbf2c78ce"
-  integrity sha512-Xh1CC8KkqIojhC+LFXd21jxlVtzoVYdGnQAi/I2+dxbmos9ghbx5TQf9/nDxc4WxaFfUQJkya0w1k6rMeyIaxQ==
+react@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
+  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.12.0-alpha.2"
+    scheduler "^0.13.6"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -4117,10 +4117,10 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.12.0-alpha.2:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.12.0.tgz#8ab17699939c0aedc5a196a657743c496538647b"
-  integrity sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Upgrade from `16.7.0-alpha.2` to `16.8.6`.

As a result of this upgrade, also fix `useFormState`. The signature of `useReducer` has changed: the third argument is now expected to be an `init` function rather than an `initialAction` object. Update tests accordingly.