### PR TITLE
Add fieldMap to state

### DIFF
--- a/src/component/Form.js
+++ b/src/component/Form.js
@@ -14,14 +14,16 @@ const Form = (props, ref) => {
   const allProps = useDefaultProps(props)
   const {
     children,
+    initialFields,
     initialValues,
     onSubmit,
     preventDefault,
     ...restProps
   } = allProps
 
+  const initialFieldMap = createMap(initialFields || "")
   const initialValueMap = createMap(initialValues || "")
-  const store = useFormState(initialValueMap)
+  const store = useFormState({ initialFieldMap, initialValueMap })
   const [{ valueMap }] = store
 
   const handleSubmit = useCallback(

--- a/src/state/__tests__/form.test.js
+++ b/src/state/__tests__/form.test.js
@@ -21,7 +21,10 @@ describe("useFormState", () => {
 
     expect(log).toHaveBeenCalledTimes(1)
     expect(log).toHaveBeenLastCalledWith([
-      expect.objectContaining({ valueMap: expect.any(Map) }),
+      expect.objectContaining({
+        fieldMap: expect.any(Map),
+        valueMap: expect.any(Map),
+      }),
       expect.any(Function),
     ])
   })
@@ -29,7 +32,7 @@ describe("useFormState", () => {
   it("applies initial values if provided", () => {
     const initialValueMap = new Map().set("a", "b")
     const Component = () => {
-      const store = useFormState(initialValueMap)
+      const store = useFormState({ initialValueMap })
       log(store)
       return <i />
     }
@@ -38,7 +41,10 @@ describe("useFormState", () => {
 
     expect(log).toHaveBeenCalledTimes(1)
     expect(log).toHaveBeenLastCalledWith([
-      expect.objectContaining({ valueMap: initialValueMap }),
+      expect.objectContaining({
+        fieldMap: expect.any(Map),
+        valueMap: initialValueMap,
+      }),
       expect.any(Function),
     ])
   })
@@ -89,6 +95,18 @@ describe("reducer's `'set value'` case", () => {
     const expected = simpleValueMap
 
     expect(valueMap).toEqual(expected)
+  })
+
+  it("preserves the rest of state", () => {
+    const type = "set value"
+    const payload = {
+      field: "a",
+      nextValue: "b",
+    }
+
+    const { fieldMap } = reducer(initialState, { payload, type })
+
+    expect(fieldMap).toBe(initialState.fieldMap)
   })
 })
 
@@ -148,13 +166,26 @@ describe("reducer's `'transform value'` case", () => {
 
     expect(valueMap).toEqual(expected)
   })
+
+  it("preserves the rest of state", () => {
+    const initialState = { valueMap: simpleValueMap }
+    const type = "transform value"
+    const payload = {
+      field: "a",
+      transformValue: toUpperCase,
+    }
+
+    const { fieldMap } = reducer(initialState, { payload, type })
+
+    expect(fieldMap).toBe(initialState.fieldMap)
+  })
 })
 
 describe("reducer's `'reset state'` case", () => {
   it("returns a new state object", () => {
     const initialState = { valueMap: simpleValueMap }
+    const payload = { initialValueMap: simpleValueMap }
     const type = "reset state"
-    const payload = initialState
 
     const nextState = reducer(initialState, { payload, type })
 
@@ -163,8 +194,8 @@ describe("reducer's `'reset state'` case", () => {
 
   it("sets `state.valueMap`", () => {
     const initialState = { valueMap: simpleValueMap }
+    const payload = { initialValueMap: simpleValueMap }
     const type = "reset state"
-    const payload = initialState
 
     const { valueMap } = reducer(initialState, { payload, type })
 

--- a/src/state/form.js
+++ b/src/state/form.js
@@ -1,6 +1,12 @@
 import { useReducer } from "react"
 
-export const init = (valueMap = new Map()) => ({ valueMap })
+export const init = (initialState = {}) => {
+  const { initialFieldMap, initialValueMap } = initialState
+  const fieldMap = initialFieldMap || new Map()
+  const valueMap = initialValueMap || new Map()
+
+  return { fieldMap, valueMap }
+}
 
 export const reducer = (state, action = {}) => {
   const { payload, type } = action
@@ -11,7 +17,7 @@ export const reducer = (state, action = {}) => {
       const { field, nextValue } = payload
       const nextValueMap = new Map(valueMap).set(field, nextValue)
 
-      return { valueMap: nextValueMap }
+      return { ...state, valueMap: nextValueMap }
     }
     case "transform value": {
       const { valueMap } = state
@@ -20,12 +26,10 @@ export const reducer = (state, action = {}) => {
       const nextValue = transformValue(currentValue)
       const nextValueMap = new Map(valueMap).set(field, nextValue)
 
-      return { valueMap: nextValueMap }
+      return { ...state, valueMap: nextValueMap }
     }
     case "reset state": {
-      const { valueMap } = payload
-
-      return init(valueMap)
+      return init(payload)
     }
     default: {
       return state
@@ -33,4 +37,5 @@ export const reducer = (state, action = {}) => {
   }
 }
 
-export const useFormState = valueMap => useReducer(reducer, valueMap, init)
+export const useFormState = initialState =>
+  useReducer(reducer, initialState, init)


### PR DESCRIPTION
Add a new property to form state, `fieldMap`.

- This property will be a flat map, similar to `valueMap`
- Entries in this map will consist of a field name key and an object value
- The object will contain metadata about the field

Also, adjust `useFormState()` and the `Form` component to accept initial values for both `fieldMap` and `valueMap`.