### PR TITLE
Use act() with TestRenderer

### DIFF
--- a/src/component/__tests__/Checkbox.test.js
+++ b/src/component/__tests__/Checkbox.test.js
@@ -1,8 +1,8 @@
 import { createElement } from "react"
-import TestRenderer from "react-test-renderer"
 
 import Checkbox from "../Checkbox"
 import { FormProvider } from "../../context/form"
+import createTestInstance from "../../util/createTestInstance"
 
 const field = "a"
 const dispatch = jest.fn()
@@ -11,7 +11,7 @@ const getState = value => ({ valueMap: new Map().set(field, value) })
 describe("Checkbox", () => {
   it("renders correctly", () => {
     const state = getState(new Set().add("b"))
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Checkbox field={field} value="b" />
         <Checkbox field={field} value="c" />
@@ -25,7 +25,7 @@ describe("Checkbox", () => {
   it("sets `checked` to `true` if the value matches", () => {
     const selectedValues = new Set().add("c").add("d")
     const state = getState(selectedValues)
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Checkbox field={field} value="b" />
         <Checkbox field={field} value="c" />
@@ -41,7 +41,7 @@ describe("Checkbox", () => {
 
   it("renders if context value is `undefined`", () => {
     const state = getState()
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Checkbox field={field} value="b" />
         <Checkbox field={field} value="c" />
@@ -56,7 +56,7 @@ describe("Checkbox", () => {
 
   it("renders if context value is `null`", () => {
     const state = getState(null)
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Checkbox field={field} value="b" />
         <Checkbox field={field} value="c" />
@@ -72,7 +72,7 @@ describe("Checkbox", () => {
   it("dispatches on change", () => {
     const valueToAppend = "d"
     const state = getState(new Set().add("b"))
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Checkbox field={field} value="b" />
         <Checkbox field={field} value="c" />
@@ -97,7 +97,7 @@ describe("Checkbox's transformValue", () => {
   it("includes a checked value in the value set", () => {
     const valueToAppend = "d"
     const state = getState(new Set().add("b"))
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Checkbox field={field} value="b" />
         <Checkbox field={field} value="c" />
@@ -120,7 +120,7 @@ describe("Checkbox's transformValue", () => {
   it("removes an unchecked value from the value set", () => {
     const valueToRemove = "d"
     const state = getState(new Set().add("c").add("d"))
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Checkbox field={field} value="b" />
         <Checkbox field={field} value="c" />
@@ -145,7 +145,7 @@ describe("Checkbox's transformValue", () => {
   it("creates a new value set if it's undefined", () => {
     const valueToAppend = "d"
     const state = getState()
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Checkbox field={field} value="b" />
         <Checkbox field={field} value="c" />

--- a/src/component/__tests__/Form.test.js
+++ b/src/component/__tests__/Form.test.js
@@ -1,22 +1,22 @@
 import { createElement } from "react"
-import TestRenderer from "react-test-renderer"
 
 import Form, { useDefaultProps } from "../Form"
 import { FormConsumer } from "../../context/form"
+import createTestInstance from "../../util/createTestInstance"
 
 const log = jest.fn()
 const preventDefault = jest.fn()
 
 describe("Form", () => {
   it("renders correctly", () => {
-    const tree = TestRenderer.create(<Form />).toJSON()
+    const tree = createTestInstance(<Form />).toJSON()
 
     expect(tree).toMatchSnapshot()
     expect(tree.props.onSubmit).toBeInstanceOf(Function)
   })
 
   it("provides a store", () => {
-    TestRenderer.create(
+    createTestInstance(
       <Form>
         <FormConsumer>{store => log(store) || null}</FormConsumer>
       </Form>
@@ -30,7 +30,7 @@ describe("Form", () => {
   })
 
   it("prevents default and calls `onSubmit` with state values", () => {
-    const tree = TestRenderer.create(<Form onSubmit={log} />).toJSON()
+    const tree = createTestInstance(<Form onSubmit={log} />).toJSON()
 
     tree.props.onSubmit({ preventDefault })
 
@@ -40,7 +40,7 @@ describe("Form", () => {
   })
 
   it("doesn't prevent or call if `preventDefault` is `false`", () => {
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <Form onSubmit={log} preventDefault={false} />
     ).toJSON()
 
@@ -52,7 +52,7 @@ describe("Form", () => {
   })
 
   it("memoizes its submit handler", () => {
-    const tree = TestRenderer.create(<Form onSubmit={log} />)
+    const tree = createTestInstance(<Form onSubmit={log} />)
     const { onSubmit: handlerA } = tree.toJSON().props
 
     tree.update(<Form onSubmit={log} />)

--- a/src/component/__tests__/MultiSelect.test.js
+++ b/src/component/__tests__/MultiSelect.test.js
@@ -1,8 +1,8 @@
 import { createElement } from "react"
-import TestRenderer from "react-test-renderer"
 
 import MultiSelect from "../MultiSelect"
 import { FormProvider } from "../../context/form"
+import createTestInstance from "../../util/createTestInstance"
 
 const field = "a"
 const dispatch = jest.fn()
@@ -11,7 +11,7 @@ const getState = value => ({ valueMap: new Map().set(field, value) })
 describe("MultiSelect", () => {
   it("renders correctly", () => {
     const state = getState()
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <MultiSelect field={field} />
       </FormProvider>
@@ -23,7 +23,7 @@ describe("MultiSelect", () => {
 
   it("casts `undefined` value to empty array", () => {
     const state = getState()
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <MultiSelect field={field} />
       </FormProvider>
@@ -35,7 +35,7 @@ describe("MultiSelect", () => {
 
   it("casts `null` value to empty array", () => {
     const state = getState(null)
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <MultiSelect field={field} />
       </FormProvider>
@@ -48,7 +48,7 @@ describe("MultiSelect", () => {
   it("dispatches on change", () => {
     const state = getState(new Set().add("b"))
     const nextValue = new Set().add("b").add("c")
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <MultiSelect field={field} />
       </FormProvider>
@@ -68,7 +68,7 @@ describe("MultiSelect", () => {
   it("memoizes its change handler", () => {
     const state = getState(new Set())
     const nextValue = new Set().add("b").add("c")
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <MultiSelect field={field} />
       </FormProvider>

--- a/src/component/__tests__/Radio.test.js
+++ b/src/component/__tests__/Radio.test.js
@@ -1,8 +1,8 @@
 import { createElement } from "react"
-import TestRenderer from "react-test-renderer"
 
 import Radio from "../Radio"
 import { FormProvider } from "../../context/form"
+import createTestInstance from "../../util/createTestInstance"
 
 const field = "a"
 const dispatch = jest.fn()
@@ -11,7 +11,7 @@ const getState = value => ({ valueMap: new Map().set(field, value) })
 describe("Radio", () => {
   it("renders correctly", () => {
     const state = getState("b")
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Radio field={field} value="b" />
         <Radio field={field} value="c" />
@@ -25,7 +25,7 @@ describe("Radio", () => {
   it("sets `checked` to `true` if the value matches", () => {
     const selectedValue = "c"
     const state = getState(selectedValue)
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Radio field={field} value="b" />
         <Radio field={field} value="c" />
@@ -41,7 +41,7 @@ describe("Radio", () => {
 
   it("renders if context value is `undefined`", () => {
     const state = getState()
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Radio field={field} value="b" />
         <Radio field={field} value="c" />
@@ -56,7 +56,7 @@ describe("Radio", () => {
 
   it("renders if context value is `null`", () => {
     const state = getState(null)
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Radio field={field} value="b" />
         <Radio field={field} value="c" />
@@ -72,7 +72,7 @@ describe("Radio", () => {
   it("dispatches on change", () => {
     const state = getState("b")
     const nextValue = "c"
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Radio field={field} value="b" />
         <Radio field={field} value="c" />

--- a/src/component/__tests__/Scope.test.js
+++ b/src/component/__tests__/Scope.test.js
@@ -1,8 +1,8 @@
 import { createElement } from "react"
-import TestRenderer from "react-test-renderer"
 
 import Scope from "../Scope"
 import { ScopeConsumer } from "../../context/scope"
+import createTestInstance from "../../util/createTestInstance"
 import { join } from "../../util/path"
 
 const field = "a"
@@ -10,7 +10,7 @@ const nestedField = "b"
 
 describe("Scope", () => {
   it("renders correctly", () => {
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <Scope field={field}>
         <i />
       </Scope>
@@ -22,7 +22,7 @@ describe("Scope", () => {
   it("provides a scope context", () => {
     let scopeValue
 
-    TestRenderer.create(
+    createTestInstance(
       <Scope field={field}>
         <ScopeConsumer>
           {contextValue => {
@@ -39,7 +39,7 @@ describe("Scope", () => {
   it("supports nested scopes", () => {
     let scopeValue
 
-    TestRenderer.create(
+    createTestInstance(
       <Scope field={field}>
         <Scope field={nestedField}>
           <ScopeConsumer>

--- a/src/component/__tests__/Select.test.js
+++ b/src/component/__tests__/Select.test.js
@@ -1,8 +1,8 @@
 import { createElement } from "react"
-import TestRenderer from "react-test-renderer"
 
 import Select from "../Select"
 import { FormProvider } from "../../context/form"
+import createTestInstance from "../../util/createTestInstance"
 
 const field = "a"
 const dispatch = jest.fn()
@@ -11,7 +11,7 @@ const getState = value => ({ valueMap: new Map().set(field, value) })
 describe("Select", () => {
   it("renders correctly", () => {
     const state = getState()
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Select field={field} />
       </FormProvider>
@@ -22,7 +22,7 @@ describe("Select", () => {
 
   it("casts `undefined` value to empty string", () => {
     const state = getState()
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Select field={field} />
       </FormProvider>
@@ -33,7 +33,7 @@ describe("Select", () => {
 
   it("casts `null` value to empty string", () => {
     const state = getState(null)
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Select field={field} />
       </FormProvider>
@@ -45,7 +45,7 @@ describe("Select", () => {
   it("dispatches on change", () => {
     const state = getState("b")
     const nextValue = "c"
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Select field={field} />
       </FormProvider>
@@ -65,7 +65,7 @@ describe("Select", () => {
   it("memoizes its change handler", () => {
     const state = getState()
     const nextValue = "b"
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Select field={field} />
       </FormProvider>

--- a/src/component/__tests__/Switch.test.js
+++ b/src/component/__tests__/Switch.test.js
@@ -1,8 +1,8 @@
 import { createElement } from "react"
-import TestRenderer from "react-test-renderer"
 
 import Switch from "../Switch"
 import { FormProvider } from "../../context/form"
+import createTestInstance from "../../util/createTestInstance"
 
 const field = "a"
 const dispatch = jest.fn()
@@ -11,7 +11,7 @@ const getState = value => ({ valueMap: new Map().set(field, value) })
 describe("Checkbox", () => {
   it("renders correctly", () => {
     const state = getState(true)
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Switch field={field} />
       </FormProvider>
@@ -22,7 +22,7 @@ describe("Checkbox", () => {
 
   it("renders if context value is undefined", () => {
     const state = getState()
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Switch field={field} />
       </FormProvider>
@@ -35,7 +35,7 @@ describe("Checkbox", () => {
 
   it("renders if context value is null", () => {
     const state = getState(null)
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Switch field={field} />
       </FormProvider>
@@ -48,7 +48,7 @@ describe("Checkbox", () => {
 
   it("sets `checked` to false if `value` is false", () => {
     const state = getState(false)
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Switch field={field} />
       </FormProvider>
@@ -61,7 +61,7 @@ describe("Checkbox", () => {
 
   it("sets `checked` to true if `value` is true", () => {
     const state = getState(true)
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Switch field={field} />
       </FormProvider>
@@ -74,7 +74,7 @@ describe("Checkbox", () => {
 
   it("dispatches on change", () => {
     const state = getState(false)
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Switch field={field} />
       </FormProvider>

--- a/src/component/__tests__/Text.test.js
+++ b/src/component/__tests__/Text.test.js
@@ -1,8 +1,8 @@
 import { createElement } from "react"
-import TestRenderer from "react-test-renderer"
 
 import Text from "../Text"
 import { FormProvider } from "../../context/form"
+import createTestInstance from "../../util/createTestInstance"
 
 const field = "a"
 const dispatch = jest.fn()
@@ -11,7 +11,7 @@ const getState = value => ({ valueMap: new Map().set(field, value) })
 describe("Text", () => {
   it("renders correctly", () => {
     const state = getState("b")
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Text field={field} />
       </FormProvider>
@@ -22,7 +22,7 @@ describe("Text", () => {
 
   it("casts `undefined` value to empty string", () => {
     const state = getState()
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Text field={field} />
       </FormProvider>
@@ -33,7 +33,7 @@ describe("Text", () => {
 
   it("casts `null` value to empty string", () => {
     const state = getState(null)
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Text field={field} />
       </FormProvider>
@@ -45,7 +45,7 @@ describe("Text", () => {
   it("dispatches on change", () => {
     const state = getState("b")
     const nextValue = "c"
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Text field={field} />
       </FormProvider>
@@ -63,7 +63,7 @@ describe("Text", () => {
   it("memoizes its change handler", () => {
     const state = getState("b")
     const nextValue = "c"
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Text field={field} />
       </FormProvider>

--- a/src/component/__tests__/TextArea.test.js
+++ b/src/component/__tests__/TextArea.test.js
@@ -1,8 +1,8 @@
 import { createElement } from "react"
-import TestRenderer from "react-test-renderer"
 
 import TextArea from "../TextArea"
 import { FormProvider } from "../../context/form"
+import createTestInstance from "../../util/createTestInstance"
 
 const field = "a"
 const dispatch = jest.fn()
@@ -11,7 +11,7 @@ const getState = (value = "b") => ({ valueMap: new Map().set(field, value) })
 describe("TextArea", () => {
   it("renders correctly", () => {
     const state = getState()
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <TextArea field={field} />
       </FormProvider>
@@ -22,7 +22,7 @@ describe("TextArea", () => {
 
   it("casts `undefined` value to empty string", () => {
     const state = { valueMap: new Map() }
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <TextArea field={field} />
       </FormProvider>
@@ -33,7 +33,7 @@ describe("TextArea", () => {
 
   it("casts `null` value to empty string", () => {
     const state = getState(null)
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <TextArea field={field} />
       </FormProvider>
@@ -45,7 +45,7 @@ describe("TextArea", () => {
   it("dispatches on change", () => {
     const state = getState()
     const nextValue = "c"
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <TextArea field={field} />
       </FormProvider>
@@ -63,7 +63,7 @@ describe("TextArea", () => {
   it("memoizes its change handler", () => {
     const state = getState()
     const nextValue = "c"
-    const tree = TestRenderer.create(
+    const tree = createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <TextArea field={field} />
       </FormProvider>

--- a/src/context/__tests__/form.test.js
+++ b/src/context/__tests__/form.test.js
@@ -1,7 +1,7 @@
 import { createElement } from "react"
-import TestRenderer from "react-test-renderer"
 
 import FormContext, { FormProvider, useFormContext } from "../form"
+import createTestInstance from "../../util/createTestInstance"
 
 const log = jest.fn()
 const dispatch = jest.fn()
@@ -21,7 +21,7 @@ describe("useFormContext", () => {
       return <i />
     }
 
-    TestRenderer.create(
+    createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Component />
       </FormProvider>
@@ -50,7 +50,7 @@ describe("useFormContext's setValue", () => {
       return <i />
     }
 
-    TestRenderer.create(
+    createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Component />
       </FormProvider>
@@ -78,7 +78,7 @@ describe("useFormContext's transformValue", () => {
       return <i />
     }
 
-    TestRenderer.create(
+    createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Component />
       </FormProvider>

--- a/src/selection/__tests__/multiple.test.js
+++ b/src/selection/__tests__/multiple.test.js
@@ -1,8 +1,8 @@
 import { createElement } from "react"
-import TestRenderer from "react-test-renderer"
 
 import useMultipleSelection from "../multiple"
 import { FormProvider } from "../../context/form"
+import createTestInstance from "../../util/createTestInstance"
 
 const field = "a"
 const log = jest.fn()
@@ -20,7 +20,7 @@ describe("useMultipleSelection", () => {
       return <i />
     }
 
-    TestRenderer.create(
+    createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Component />
       </FormProvider>
@@ -48,7 +48,7 @@ describe("useMultipleSelection's selectValues", () => {
       return <i />
     }
 
-    TestRenderer.create(
+    createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Component />
       </FormProvider>

--- a/src/selection/__tests__/simple.test.js
+++ b/src/selection/__tests__/simple.test.js
@@ -1,8 +1,8 @@
 import { createElement } from "react"
-import TestRenderer from "react-test-renderer"
 
 import useSimpleSelection from "../simple"
 import { FormProvider } from "../../context/form"
+import createTestInstance from "../../util/createTestInstance"
 
 const field = "a"
 const dispatch = jest.fn()
@@ -19,7 +19,7 @@ describe("useSimpleSelection", () => {
       return <i />
     }
 
-    TestRenderer.create(
+    createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Component />
       </FormProvider>
@@ -44,7 +44,7 @@ describe("useSimpleSelection", () => {
       return <i />
     }
 
-    TestRenderer.create(
+    createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Component />
       </FormProvider>
@@ -63,7 +63,7 @@ describe("useSimpleSelection", () => {
       return <i />
     }
 
-    TestRenderer.create(
+    createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Component />
       </FormProvider>
@@ -85,7 +85,7 @@ describe("useSimpleSelection's selectValue", () => {
       return <i />
     }
 
-    TestRenderer.create(
+    createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Component />
       </FormProvider>

--- a/src/selection/__tests__/single.test.js
+++ b/src/selection/__tests__/single.test.js
@@ -1,8 +1,8 @@
 import { createElement } from "react"
-import TestRenderer from "react-test-renderer"
 
 import useSingleSelection from "../single"
 import { FormProvider } from "../../context/form"
+import createTestInstance from "../../util/createTestInstance"
 
 const field = "a"
 const dispatch = jest.fn()
@@ -19,7 +19,7 @@ describe("useSingleSelection", () => {
       return <i />
     }
 
-    TestRenderer.create(
+    createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Component />
       </FormProvider>
@@ -44,7 +44,7 @@ describe("useSingleSelection", () => {
       return <i />
     }
 
-    TestRenderer.create(
+    createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Component />
       </FormProvider>
@@ -63,7 +63,7 @@ describe("useSingleSelection", () => {
       return <i />
     }
 
-    TestRenderer.create(
+    createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Component />
       </FormProvider>
@@ -85,7 +85,7 @@ describe("useSingleSelection's selectValue", () => {
       return <i />
     }
 
-    TestRenderer.create(
+    createTestInstance(
       <FormProvider value={[state, dispatch]}>
         <Component />
       </FormProvider>

--- a/src/util/__tests__/createTestInstance.test.js
+++ b/src/util/__tests__/createTestInstance.test.js
@@ -1,0 +1,18 @@
+import { createElement } from "react"
+
+import createTestInstance from "../createTestInstance"
+
+describe("createTestInstance", () => {
+  it("returns a TestRenderer instance", () => {
+    const instance = createTestInstance(<i />)
+
+    expect(instance).toMatchObject({
+      getInstance: expect.any(Function),
+      root: expect.anything(),
+      toJSON: expect.any(Function),
+      toTree: expect.any(Function),
+      unmount: expect.any(Function),
+      update: expect.any(Function),
+    })
+  })
+})

--- a/src/util/createTestInstance.js
+++ b/src/util/createTestInstance.js
@@ -1,0 +1,11 @@
+import TestRenderer, { act } from "react-test-renderer"
+
+export default (...args) => {
+  let instance
+
+  act(() => {
+    instance = TestRenderer.create(...args)
+  })
+
+  return instance
+}


### PR DESCRIPTION
Add a utility, `createTestInstance()`, to wrap calls to `TestRenderer.create()` with `act()`.